### PR TITLE
Support string ssh ports

### DIFF
--- a/orka-teamcity-plugin-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
+++ b/orka-teamcity-plugin-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
@@ -148,12 +148,12 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
                     OrkaCloudInstance cloudInstance = image.startNewInstance(instanceId);
                     cloudInstance.setStatus(InstanceStatus.RUNNING);
                     cloudInstance.setHost(instance.get().getHost());
-                    cloudInstance.setPort(instance.get().getSSHPort());
+                    cloudInstance.setPort(Integer.parseInt(instance.get().getSSHPort()));
                     return cloudInstance;
                 }
             }
 
-        } catch (IOException e) {
+        } catch (IOException | NumberFormatException e) {
             LOG.debug(String.format("createInstanceFromExistingAgent error", e));
         }
         LOG.debug("createInstanceFromExistingAgent nothing found.");

--- a/orka-teamcity-plugin-server/src/main/java/com/macstadium/orka/client/VMInstance.java
+++ b/orka-teamcity-plugin-server/src/main/java/com/macstadium/orka/client/VMInstance.java
@@ -10,11 +10,11 @@ public class VMInstance {
     private String host;
 
     @SerializedName("ssh_port")
-    private int sshPort;
+    private String sshPort;
 
     private String image;
 
-    public VMInstance(String id, String host, int sshPort, String image) {
+    public VMInstance(String id, String host, String sshPort, String image) {
         this.id = id;
         this.host = host;
         this.sshPort = sshPort;
@@ -33,7 +33,7 @@ public class VMInstance {
         return this.image;
     }
 
-    public int getSSHPort() {
+    public String getSSHPort() {
         return this.sshPort;
     }
 
@@ -44,7 +44,7 @@ public class VMInstance {
         result = prime * result + ((host == null) ? 0 : host.hashCode());
         result = prime * result + ((id == null) ? 0 : id.hashCode());
         result = prime * result + ((image == null) ? 0 : image.hashCode());
-        result = prime * result + sshPort;
+        result = prime * result + ((sshPort == null) ? 0 : image.hashCode());;
         return result;
     }
 
@@ -81,7 +81,11 @@ public class VMInstance {
         } else if (!image.equals(other.image)) {
             return false;
         }
-        if (sshPort != other.sshPort) {
+        if (sshPort == null) {
+            if (other.sshPort != null) {
+                return false;
+            }
+        } else if (!sshPort.equals(other.sshPort)) {
             return false;
         }
         return true;

--- a/orka-teamcity-plugin-server/src/test/java/com/macstadium/orka/OrkaCloudClientTest.java
+++ b/orka-teamcity-plugin-server/src/test/java/com/macstadium/orka/OrkaCloudClientTest.java
@@ -95,7 +95,7 @@ public class OrkaCloudClientTest {
         String instanceId = "instanceId";
 
         OrkaClient orkaClient = mock(OrkaClient.class);
-        VMInstance vmInstance = new VMInstance(instanceId, "host", 22, imageId);
+        VMInstance vmInstance = new VMInstance(instanceId, "host", "22", imageId);
         VMResponse response = new VMResponse("first", "deployed", 12, "Mojave.img", "firstImage", "default",
                 new VMInstance[] { vmInstance });
         when(orkaClient.getVM(anyString())).thenReturn(response);


### PR DESCRIPTION
The port can be "N/A".
Make sure this is parsed correctly.
Still expect a number when deploying an agent.