### PR TITLE
Allow node host mapping

### DIFF
--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaConstants.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaConstants.java
@@ -31,6 +31,8 @@ public class OrkaConstants {
     @NotNull
     public static final String INSTANCE_LIMIT = "cloud.orka.vm.limit";
     @NotNull
+    public static final String NODE_MAPPINGS = "cloud.orka.node.mappings";
+    @NotNull
     public static final int UNLIMITED_INSTANCES = -1;
 
     public String getOrkaEndpoint() {
@@ -67,5 +69,9 @@ public class OrkaConstants {
 
     public String getInstanceLimit() {
         return INSTANCE_LIMIT;
+    }
+
+    public String getNodeMappings() {
+        return NODE_MAPPINGS;
     }
 }

--- a/macstadium-orka-server/src/main/resources/buildServerResources/images.js
+++ b/macstadium-orka-server/src/main/resources/buildServerResources/images.js
@@ -44,6 +44,16 @@ function OrkaImagesViewModel(BS, $F, ko, $, config) {
 
   self.agentDirectory = ko.observable().extend({ required: true });
 
+  self.showMappings = ko.observable(false);
+  self.initialNodeMappings = ko.observable();
+  self.nodeMappings = ko.observable();
+
+  self.initialNodeMappings.subscribe(function(data) {
+    if (data) {
+      self.nodeMappings(data.trim());
+    }
+  });
+
   self.loadInfo = function() {
     self.loadingVms(true);
 

--- a/macstadium-orka-server/src/main/resources/buildServerResources/settings.css
+++ b/macstadium-orka-server/src/main/resources/buildServerResources/settings.css
@@ -5,3 +5,7 @@
 .runnerFormTable {
   padding-bottom: 0;
 }
+
+.mappings.hidden {
+  display: none !important;
+}

--- a/macstadium-orka-server/src/main/resources/buildServerResources/settings.jsp
+++ b/macstadium-orka-server/src/main/resources/buildServerResources/settings.jsp
@@ -125,6 +125,23 @@
                 </span>
             </td>
         </tr>
+
+        <tr class="advancedSetting">
+            <th><label for="${constants.agentDirectory}">Node mappings:</label></th>
+            <td>
+                <div data-bind="visible: showMappings" style="display: none">
+                    <div>Edit Node Mappings:</div>
+                    <textarea name="prop:${constants.nodeMappings}" class="mappings"
+                              rows="5" cols="30"
+                              data-bind="initValue: initialNodeMappings, textInput: nodeMappings">
+                        <c:out value="${propertiesBean.properties[constants.nodeMappings]}"/>
+                    </textarea>
+                </div>
+                <a href="#" data-bind="click: function() { showMappings(true) }, visible: !showMappings()">Node Mappings</a>
+                <span class="smallNote">Overwrite the default host address used to connect to an Orka VM.</span>
+                <span class="smallNote">Mappings are in "PRIVATE_HOST;PUBLIC_HOST" format, separated by a new line.</span>
+            </td>
+        </tr>
     </table>
 </div>
 


### PR DESCRIPTION
Allows mapping between the private address of a node to its public one. This way the plugin can use the public address to connect to the VM instead of the private one.