### PR TITLE
Terminate agent on VM initialization failiure

### DIFF
--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
@@ -237,6 +237,7 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
         } catch (IOException | InterruptedException e) {
             LOG.debug("setUpVM error", e);
             instance.setErrorInfo(new CloudErrorInfo(e.getMessage(), e.toString(), e));
+            this.terminateInstance(instance);
         }
     }
 


### PR DESCRIPTION
If VM fails during initialization, the agent is never fully set up and cannot execute jobs.
TeamCity does not remove such agents automatically and if there are not more slots for new agents, it cannot create new ones.
This means all jobs are stuck and require manual intervation.
Delete failed agents to prevent this.