### PR TITLE
[ORKA-203] Retry deletion of failed instances

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -33,6 +33,7 @@
     </module>
 
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
@@ -195,5 +196,9 @@
             <message key="name.invalidPattern" value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="SuppressWarnings">
+            <property name="id" value="checkstyle:suppresswarnings"/>
+        </module>
     </module>
+    <module name="SuppressWarningsFilter"/>
 </module>

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/AsyncExecutor.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/AsyncExecutor.java
@@ -2,11 +2,15 @@ package com.macstadium.orka;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import jetbrains.buildServer.serverSide.TeamCityProperties;
 import jetbrains.buildServer.util.NamedThreadFactory;
 import jetbrains.buildServer.util.ThreadUtil;
 import jetbrains.buildServer.util.executors.ExecutorsFactory;
+
+import org.jetbrains.annotations.NotNull;
 
 public class AsyncExecutor {
     private final ScheduledExecutorService executor;
@@ -18,12 +22,21 @@ public class AsyncExecutor {
         this.executor = ExecutorsFactory.newFixedScheduledExecutor(this.threadPrefix, threadCount);
     }
 
-    public Future<?> submit(final String taskName, final Runnable runnable) {
+    public Future<?> submit(@NotNull final String taskName, @NotNull final Runnable runnable) {
         return this.executor.submit(new Runnable() {
             public void run() {
                 NamedThreadFactory.executeWithNewThreadName(taskName, runnable);
             }
         });
+    }
+
+    public ScheduledFuture<?> scheduleWithFixedDelay(@NotNull final String taskName, @NotNull final Runnable task,
+            final long initialDelay, final long delay, final TimeUnit unit) {
+        return executor.scheduleWithFixedDelay(new Runnable() {
+            public void run() {
+                NamedThreadFactory.executeWithNewThreadName(taskName, task);
+            }
+        }, initialDelay, delay, unit);
     }
 
     public void dispose() {

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudInstance.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudInstance.java
@@ -30,12 +30,21 @@ public class OrkaCloudInstance implements CloudInstance {
     private volatile InstanceStatus status;
     @Nullable
     private volatile CloudErrorInfo errorInfo;
+    private boolean markedForTermination;
 
     public OrkaCloudInstance(@NotNull final OrkaCloudImage image, @NotNull final String instanceId) {
         this.image = image;
         this.status = InstanceStatus.SCHEDULED_TO_START;
         this.id = instanceId;
         this.startDate = new Date();
+    }
+
+    public boolean isMarkedForTermination() {
+        return markedForTermination;
+    }
+
+    public void setMarkedForTermination(boolean markedForTermination) {
+        this.markedForTermination = markedForTermination;
     }
 
     @NotNull

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoveFailedInstancesTask.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoveFailedInstancesTask.java
@@ -1,0 +1,74 @@
+package com.macstadium.orka;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.macstadium.orka.client.DeletionResponse;
+import com.macstadium.orka.client.VMResponse;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jetbrains.buildServer.clouds.CloudImage;
+import jetbrains.buildServer.log.Loggers;
+
+public class RemoveFailedInstancesTask implements Runnable {
+    private static final Logger LOG = Logger.getInstance(Loggers.CLOUD_CATEGORY_ROOT + OrkaConstants.TYPE);
+    private OrkaCloudClient client;
+
+    public RemoveFailedInstancesTask(OrkaCloudClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public void run() {
+        this.client.getImages().forEach(image -> this.terminateFailedInstances(image));
+    }
+
+    private void terminateFailedInstances(CloudImage image) {
+        List<OrkaCloudInstance> instancesToTerminate = image.getInstances().stream()
+                .map(instance -> (OrkaCloudInstance) instance).filter(instance -> instance.isMarkedForTermination())
+                .collect(Collectors.toList());
+
+        if (instancesToTerminate.size() > 0) {
+            try {
+                Set<String> runningInstances = this.getRunningInstances(image.getName());
+                instancesToTerminate.forEach(instance -> {
+                    if (runningInstances.contains(instance.getInstanceId())) {
+                        this.tryDeleteVM(instance);
+                    } else {
+                        this.terminateInstance(instance);
+                    }
+                });
+
+            } catch (IOException e) {
+                LOG.info(String.format("Failed to execute terminate failed instances for image: %s", image.getName()),
+                        e);
+            }
+        }
+    }
+
+    private Set<String> getRunningInstances(String imageName) throws IOException {
+        VMResponse vmResponse = this.client.getVM(imageName);
+        return Arrays.stream(vmResponse.getInstances()).map(instance -> instance.getId()).collect(Collectors.toSet());
+    }
+
+    private void tryDeleteVM(OrkaCloudInstance instance) {
+        try {
+            DeletionResponse response = this.client.deleteVM(instance.getInstanceId());
+            if (!response.hasErrors()) {
+                this.terminateInstance(instance);
+            } else {
+                LOG.info(String.format("Failed to terminate VM: %s and message: %s", 
+                    instance.getInstanceId(), Arrays.toString(response.getErrors())));
+            }
+        } catch (IOException e) {
+            LOG.info(String.format("Failed to terminate VM: %s", instance.getInstanceId()), e);
+        }
+    }
+
+    private void terminateInstance(OrkaCloudInstance failedInstance) {
+        failedInstance.getImage().terminateInstance(failedInstance.getInstanceId());
+    }
+}

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/client/DeletionResponse.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/client/DeletionResponse.java
@@ -3,7 +3,22 @@ package com.macstadium.orka.client;
 public class DeletionResponse {
     private String message;
 
+    private OrkaError[] errors;
+
+    public DeletionResponse(String message, OrkaError[] errors) {
+        this.message = message;
+        this.errors = errors != null ? errors.clone() : new OrkaError[] {};
+    }
+
     public String getMessage() {
         return this.message;
+    }
+
+    public OrkaError[] getErrors() {
+        return this.errors.clone();
+    }
+
+    public boolean hasErrors() {
+        return this.errors != null && this.errors.length > 0;
     }
 }

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/client/OrkaClient.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/client/OrkaClient.java
@@ -17,12 +17,13 @@ import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-public class OrkaClient {
+public class OrkaClient implements AutoCloseable {
     private static final OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
 
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
     private static final String LOGIN_PATH = "/token";
     private static final String RESOURCE_PATH = "/resources";
+    private static final String TOKEN_PATH = "/token";
     private static final String VM_PATH = RESOURCE_PATH + "/vm";
     private static final String VM_STATUS_PATH = VM_PATH + "/status";
     private static final String NODE_PATH = RESOURCE_PATH + "/node";
@@ -166,5 +167,10 @@ public class OrkaClient {
         try (Response response = client.newCall(request).execute()) {
             return response.body().string();
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.delete(this.endpoint + TOKEN_PATH, "");
     }
 }

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/web/VmHandler.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/web/VmHandler.java
@@ -27,8 +27,7 @@ public class VmHandler implements RequestHandler {
         LOG.debug(String.format("Get VMs with endpoint: %s, and user email: %s", endpoint, user));
 
         List<VMResponse> vmResponse = Collections.emptyList();
-        try {
-            OrkaClient client = new OrkaClient(endpoint, user, password);
+        try (OrkaClient client = new OrkaClient(endpoint, user, password)) {
             vmResponse = client.getVMs();
             LOG.debug(String.format("VMs size received: %s", vmResponse.size()));
         } catch (IOException e) {

--- a/macstadium-orka-server/src/test/java/com/macstadium/orka/RemoveFailedInstancesTaskTest.java
+++ b/macstadium-orka-server/src/test/java/com/macstadium/orka/RemoveFailedInstancesTaskTest.java
@@ -1,0 +1,142 @@
+package com.macstadium.orka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.macstadium.orka.client.DeletionResponse;
+import com.macstadium.orka.client.OrkaClient;
+import com.macstadium.orka.client.OrkaError;
+import com.macstadium.orka.client.VMInstance;
+import com.macstadium.orka.client.VMResponse;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.testng.annotations.Test;
+
+@Test
+public class RemoveFailedInstancesTaskTest {
+    private String existingRunningVMId = "existing";
+    private String failedRunningVMId = "failed";
+
+    public void when_run_task_and_no_instances_to_terminate_should_keep_running_instances() throws IOException {
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"),
+                mock(OrkaClient.class), mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        OrkaCloudInstance instance = image.startNewInstance("instanceId");
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(1, image.getInstances().size());
+        assertSame(instance, image.getInstances().toArray()[0]);
+    }
+
+    public void when_run_task_and_one_instance_to_terminate_with_no_vm_should_terminate_instance() throws IOException {
+        OrkaClient orkaClient = getOrkaClientMock(new String[] { existingRunningVMId });
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"), orkaClient,
+                mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        OrkaCloudInstance instance = image.startNewInstance(failedRunningVMId);
+        instance.setMarkedForTermination(true);
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(0, image.getInstances().size());
+    }
+
+    public void when_run_task_and_one_instance_to_terminate_with_vm_should_terminate_instance_and_vm()
+            throws IOException {
+        OrkaClient orkaClient = getOrkaClientMock(new String[] { existingRunningVMId, failedRunningVMId });
+        DeletionResponse deletionResponse = new DeletionResponse("Success", null);
+        when(orkaClient.deleteVM(failedRunningVMId)).thenReturn(deletionResponse);
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"), orkaClient,
+                mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        OrkaCloudInstance failedInstance = image.startNewInstance(failedRunningVMId);
+        failedInstance.setMarkedForTermination(true);
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(0, image.getInstances().size());
+        verify(orkaClient).deleteVM(failedRunningVMId);
+    }
+
+    @SuppressWarnings("checkstyle:linelength")
+    public void when_run_task_and_one_instance_to_terminate_with_vm_should_terminate_instance_and_vm_and_keep_running_instances()
+            throws IOException {
+        OrkaClient orkaClient = getOrkaClientMock(new String[] { existingRunningVMId, failedRunningVMId });
+        DeletionResponse deletionResponse = new DeletionResponse("Success", null);
+        when(orkaClient.deleteVM(failedRunningVMId)).thenReturn(deletionResponse);
+
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"), orkaClient,
+                mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        final OrkaCloudInstance runningInstance = image.startNewInstance(existingRunningVMId);
+        OrkaCloudInstance failedInstance = image.startNewInstance(failedRunningVMId);
+        failedInstance.setMarkedForTermination(true);
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(1, image.getInstances().size());
+        verify(orkaClient).deleteVM(failedRunningVMId);
+        assertSame(runningInstance, image.getInstances().toArray()[0]);
+    }
+
+    public void when_run_task_and_one_instance_to_terminate_with_vm_should_and_delete_throws_should_keep_instance()
+            throws IOException {
+        OrkaClient orkaClient = getOrkaClientMock(new String[] { existingRunningVMId, failedRunningVMId });
+        when(orkaClient.deleteVM(failedRunningVMId)).thenThrow(new IOException());
+
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"), orkaClient,
+                mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        OrkaCloudInstance failedInstance = image.startNewInstance(failedRunningVMId);
+        failedInstance.setMarkedForTermination(true);
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(1, image.getInstances().size());
+        verify(orkaClient).deleteVM(failedRunningVMId);
+        assertSame(failedInstance, image.getInstances().toArray()[0]);
+    }
+
+    @SuppressWarnings("checkstyle:linelength")
+    public void when_run_task_and_one_instance_to_terminate_with_vm_should_and_delete_returns_error_should_keep_instance()
+            throws IOException {
+        OrkaClient orkaClient = getOrkaClientMock(new String[] { existingRunningVMId, failedRunningVMId });
+        DeletionResponse deletionResponse = new DeletionResponse("Error", new OrkaError[] { new OrkaError() });
+        when(orkaClient.deleteVM(failedRunningVMId)).thenReturn(deletionResponse);
+
+        OrkaCloudClient client = new OrkaCloudClient(Utils.getCloudClientParametersMock("imageId"), orkaClient,
+                mock(AsyncExecutor.class), mock(RemoteAgent.class), mock(SSHUtil.class));
+        OrkaCloudImage image = (OrkaCloudImage) client.getImages().toArray()[0];
+        OrkaCloudInstance failedInstance = image.startNewInstance(failedRunningVMId);
+        failedInstance.setMarkedForTermination(true);
+
+        RemoveFailedInstancesTask task = new RemoveFailedInstancesTask(client);
+        task.run();
+
+        assertEquals(1, image.getInstances().size());
+        verify(orkaClient).deleteVM(failedRunningVMId);
+        assertSame(failedInstance, image.getInstances().toArray()[0]);
+    }
+
+    private OrkaClient getOrkaClientMock(String[] vmIDs) throws IOException {
+        OrkaClient orkaClient = mock(OrkaClient.class);
+        VMInstance[] vms = (VMInstance[]) Arrays.stream(vmIDs).map(vmId -> new VMInstance(vmId, "host", "22", "image"))
+                .toArray(VMInstance[]::new);
+        VMResponse response = new VMResponse("first", "deployed", 12, "Mojave.img", "firstImage", "default", vms);
+        when(orkaClient.getVM(anyString())).thenReturn(response);
+
+        return orkaClient;
+    }
+}

--- a/macstadium-orka-server/src/test/java/com/macstadium/orka/Utils.java
+++ b/macstadium-orka-server/src/test/java/com/macstadium/orka/Utils.java
@@ -1,0 +1,45 @@
+package com.macstadium.orka;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jetbrains.buildServer.clouds.CloudClientParameters;
+import jetbrains.buildServer.clouds.CloudImageParameters;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class Utils {
+    public static CloudClientParameters getCloudClientParametersMock(String imageId) {
+        return getCloudClientParametersMock(imageId, null);
+    }
+
+    public static CloudClientParameters getCloudClientParametersMock(String imageId, String nodeMappings) {
+        final Map<String, String> params = new HashMap<String, String>();
+        params.put(OrkaConstants.AGENT_DIRECTORY, "dir");
+        params.put(OrkaConstants.ORKA_ENDPOINT, "endpoint");
+        params.put(OrkaConstants.ORKA_USER, "user");
+        params.put(OrkaConstants.ORKA_PASSWORD, "password");
+        params.put(OrkaConstants.VM_NAME, imageId);
+        params.put(OrkaConstants.VM_USER, "vm_user");
+        params.put(OrkaConstants.VM_PASSWORD, "vm_pass");
+        params.put(CloudImageParameters.AGENT_POOL_ID_FIELD, "100");
+        params.put(OrkaConstants.INSTANCE_LIMIT, "100");
+        params.put(OrkaConstants.NODE_MAPPINGS, nodeMappings);
+
+        CloudClientParameters mock = mock(CloudClientParameters.class);
+        when(mock.getParameter(anyString())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                return params.get(args[0]);
+            }
+        });
+
+        return mock;
+    }
+}


### PR DESCRIPTION
If an instance fails to delete for some reason, we leave it in error state.
This allows people to see that there is something wrong.
However, that instance is never removed until the server is restarted. This way it take one slot in TeamCity and one less instance can be created.

Create a background job that will check for failed instances every 5 min and will retry to delete them.