### PR TITLE
[ORKA-210] Set timeout for SSH connections

### DIFF
--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
@@ -247,6 +247,7 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
             instance.setStatus(InstanceStatus.RUNNING);
         } catch (IOException | InterruptedException e) {
             LOG.debug("setUpVM error", e);
+            instance.setStatus(InstanceStatus.ERROR);
             instance.setErrorInfo(new CloudErrorInfo(e.getMessage(), e.toString(), e));
             this.terminateNonInitilizedInstance(instance);
         }
@@ -310,6 +311,7 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
                 }
             } catch (IOException e) {
                 LOG.debug("terminateInstance error", e);
+                orkaInstance.setStatus(InstanceStatus.ERROR);
                 this.setInstanceForDeletion(orkaInstance, new CloudErrorInfo(e.getMessage(), e.toString(), e));
             }
         });

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoveFailedInstancesTask.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoveFailedInstancesTask.java
@@ -23,7 +23,9 @@ public class RemoveFailedInstancesTask implements Runnable {
 
     @Override
     public void run() {
+        LOG.debug("Running remove failed instances...");
         this.client.getImages().forEach(image -> this.terminateFailedInstances(image));
+        LOG.debug("Failed instances task completed.");
     }
 
     private void terminateFailedInstances(CloudImage image) {
@@ -33,8 +35,12 @@ public class RemoveFailedInstancesTask implements Runnable {
 
         if (instancesToTerminate.size() > 0) {
             try {
+                LOG.debug(String.format("Failed instances found for image %s", image.getName()));
+
                 Set<String> runningInstances = this.getRunningInstances(image.getName());
                 instancesToTerminate.forEach(instance -> {
+                    LOG.debug(String.format("Removing instance with id: %s", instance.getInstanceId()));
+
                     if (runningInstances.contains(instance.getInstanceId())) {
                         this.tryDeleteVM(instance);
                     } else {
@@ -60,8 +66,8 @@ public class RemoveFailedInstancesTask implements Runnable {
             if (!response.hasErrors()) {
                 this.terminateInstance(instance);
             } else {
-                LOG.info(String.format("Failed to terminate VM: %s and message: %s", 
-                    instance.getInstanceId(), Arrays.toString(response.getErrors())));
+                LOG.info(String.format("Failed to terminate VM: %s and message: %s", instance.getInstanceId(),
+                        Arrays.toString(response.getErrors())));
             }
         } catch (IOException e) {
             LOG.info(String.format("Failed to terminate VM: %s", instance.getInstanceId()), e);


### PR DESCRIPTION
If the SSH connection fails for some reason while we execute a remote command, reading of the command input hangs forever.
This way the VM either never initializes and cannot be removed or cannot be terminated.