### PR TITLE
Fi Agent compatibility

### DIFF
--- a/macstadium-orka-agent/src/main/java/com/macstadium/orka/OrkaAgent.java
+++ b/macstadium-orka-agent/src/main/java/com/macstadium/orka/OrkaAgent.java
@@ -51,5 +51,8 @@ public class OrkaAgent {
         List<String> contents = FileUtil.readFile(metadataFile);
         configuration.addConfigurationParameter(CommonConstants.INSTANCE_ID_PARAM_NAME, contents.get(0));
         configuration.addConfigurationParameter(CommonConstants.IMAGE_ID_PARAM_NAME, contents.get(1));
+        if (contents.size() > 2) {
+            configuration.addConfigurationParameter(CommonConstants.STARTING_INSTANCE_ID_CONFIG_PARAM, contents.get(2));
+        }
     }
 }

--- a/macstadium-orka-common/src/main/java/com/macstadium/orka/CommonConstants.java
+++ b/macstadium-orka-common/src/main/java/com/macstadium/orka/CommonConstants.java
@@ -3,5 +3,7 @@ package com.macstadium.orka;
 public class CommonConstants {
     public static final String IMAGE_ID_PARAM_NAME = "cloud.orka.image.id";
     public static final String INSTANCE_ID_PARAM_NAME = "cloud.orka.instance.id";
+    public static final String STARTING_INSTANCE_ID_PARAM_NAME = "cloud.orka.startingInstanceId";
     public static final String METADATA_FILE_PREFIX = "orka_metadata_file";
+    public static final String STARTING_INSTANCE_ID_CONFIG_PARAM = "teamcity.agent.startingInstanceId";
 }

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/OrkaCloudClient.java
@@ -211,12 +211,12 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
         OrkaCloudInstance instance = cloudImage.startNewInstance(instanceId);
         LOG.debug(String.format("startNewInstance with temp id: %s", instanceId));
 
-        this.scheduledExecutorService.submit(() -> this.setUpVM(cloudImage, instance));
+        this.scheduledExecutorService.submit(() -> this.setUpVM(cloudImage, instance, data));
 
         return instance;
     }
 
-    private void setUpVM(OrkaCloudImage image, OrkaCloudInstance instance) {
+    private void setUpVM(OrkaCloudImage image, OrkaCloudInstance instance, @NotNull final CloudInstanceUserData data) {
         try {
             LOG.debug(
                     String.format("setUpVM deploying vm: %s, in namespace: %s", image.getName(), image.getNamespace()));
@@ -241,7 +241,7 @@ public class OrkaCloudClient extends BuildServerAdapter implements CloudClientEx
             LOG.debug("setUpVM waiting for SSH to be enabled");
             this.waitForVM(host, sshPort);
             this.remoteAgent.startAgent(instanceId, image.getId(), host, sshPort, image.getUser(), image.getPassword(),
-                    this.agentDirectory);
+                    this.agentDirectory, data);
             instance.setStatus(InstanceStatus.RUNNING);
         } catch (IOException | InterruptedException e) {
             LOG.debug("setUpVM error", e);

--- a/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoteAgent.java
+++ b/macstadium-orka-server/src/main/java/com/macstadium/orka/RemoteAgent.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import jetbrains.buildServer.clouds.CloudInstanceUserData;
 import jetbrains.buildServer.clouds.InstanceStatus;
 import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.util.FileUtil;
@@ -16,6 +17,8 @@ import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.connection.channel.direct.Session.Command;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 
+import org.jetbrains.annotations.NotNull;
+
 public class RemoteAgent {
     private static final Logger LOG = Logger.getInstance(Loggers.CLOUD_CATEGORY_ROOT + OrkaConstants.TYPE);
     private static final int SSH_TIMEOUT = 60 * 1000;
@@ -24,10 +27,17 @@ public class RemoteAgent {
     private static final String STOP_COMMAND_FORMAT = "%s/bin/agent.sh stop";
 
     public void startAgent(String instanceId, String imageId, String host, int sshPort, String sshUser,
-            String sshPassword, String agentDirectory) throws IOException {
+            String sshPassword, String agentDirectory, @NotNull final CloudInstanceUserData data) throws IOException {
 
         File tempFile = File.createTempFile(CommonConstants.METADATA_FILE_PREFIX, ".tmp");
-        FileUtil.writeFileAndReportErrors(tempFile, instanceId + System.lineSeparator() + imageId);
+        String text = instanceId + System.lineSeparator() + imageId;
+        if (data.getCustomAgentConfigurationParameters()
+                .containsKey(CommonConstants.STARTING_INSTANCE_ID_CONFIG_PARAM)) {
+            text = text + System.lineSeparator() + data.getCustomAgentConfigurationParameters()
+                    .get(CommonConstants.STARTING_INSTANCE_ID_CONFIG_PARAM);
+        }
+
+        FileUtil.writeFileAndReportErrors(tempFile, text);
 
         LOG.debug("startAgentOnVM starting...");
 


### PR DESCRIPTION
As of 2023.11.5 the agent needs to pass teamcity.agent.startingInstanceId to authenticate to the server. This ID is passed from the server to the plugin when a new instance is started. And we need to pass it to the agent